### PR TITLE
feat: add `--test` flag to the ronin-exploits CLI

### DIFF
--- a/lib/ronin/exploits/cli/commands/run.rb
+++ b/lib/ronin/exploits/cli/commands/run.rb
@@ -52,6 +52,7 @@ module Ronin
         #     -f, --file FILE                  The exploit file to load
         #     -p, --param NAME=VALUE           Sets a param
         #     -D, --dry-run                    Builds the exploit but does not launch it
+        #     -T  --test                       Runs only the exploit test
         #         --payload-file FILE          Load the payload from the given Ruby file
         #         --read-payload FILE          Reads the payload string from the file
         #         --payload-string STRING      Uses the raw payload string instead
@@ -85,10 +86,14 @@ module Ronin
           include Core::CLI::Options::Param
           include Core::CLI::Logging
           include CommandKit::Printing::Indent
+          include Support::CLI::Printing
 
           # Exploit options
           option :dry_run, short: '-D',
                            desc: 'Builds the exploit but does not launch it'
+
+          option :test, short: '-T',
+                        desc: 'Runs only the exploit test'
 
           # Payload options
           option :payload_file, value: {
@@ -273,7 +278,12 @@ module Ronin
             validate_payload
             initialize_exploit
             validate_exploit
-            run_exploit
+
+            if options[:test]
+              run_test
+            else
+              run_exploit
+            end
 
             if options[:irb]
               start_shell
@@ -380,6 +390,24 @@ module Ronin
               print_error "an unhandled exception occurred while running the exploit #{@exploit.class_id}"
               exit(-1)
             end
+          end
+
+          #
+          # Run the exploit's test method, and print the result.
+          #
+          def run_test
+            case (result = @exploit.perform_test)
+            when TestResult::Vulnerable
+              print_positive "Vulnerable: #{result}"
+            when TestResult::NotVulnerable
+              print_negative "NotVulnerable: #{result}"
+            when TestResult::Unknown
+              print_warning "Unknown: #{result}"
+            else
+              print_error "Unexpected result: #{result.inspect}"
+            end
+
+            result
           end
 
           #

--- a/lib/ronin/exploits/cli/commands/run.rb
+++ b/lib/ronin/exploits/cli/commands/run.rb
@@ -406,8 +406,6 @@ module Ronin
             else
               print_error "Unexpected result: #{result.inspect}"
             end
-
-            result
           end
 
           #

--- a/man/ronin-exploits-run.1.md
+++ b/man/ronin-exploits-run.1.md
@@ -28,6 +28,9 @@ Loads and runs an exploit.
 `-D`, `--dry-run`
 : Builds the exploit but does not launch it.
 
+`-T`, `--test`
+: Runs only the exploit test.
+
 `--payload-file` *FILE*
 : Load the payload from the given Ruby file.
 


### PR DESCRIPTION
Currently, to test whether a target is vulnerable, users need to run something like:

    ronin-exploits --file=path/to/exploit.rb --dry-run --irb

and then run "test" from the REPL.

This feature would allow users to instead run:

    ronin-exploits --file=path/to/exploit.rb --test

Printed output looks like one of these lines, depending on the return type:

    [+] Vulnerable: <test result message>
    [-] NotVulnerable: <test result message>
    [~] Unknown: <test result message>
    [!] Unexpected: <other result type>

What drove me to submit this feature is my thought that a flag like this would have sped up feedback loops while I was iterating on https://github.com/ronin-rb/community-pocs/blob/main/exploits/activemq/CVE-2023-46604.rb